### PR TITLE
12-enhancement-cli-output-showing-wrong-host-url-to-open

### DIFF
--- a/src/postScaffold.ts
+++ b/src/postScaffold.ts
@@ -33,6 +33,13 @@ export function postScaffold(options: ScaffoldOptions) {
  1. navigate to: ${chalk.green(options['projectName'])}
  2. activate pipenv: ${chalk.green("'pipenv shell'")}
  3. run the project: ${chalk.green("'npm run dirt-dev'")}
+ 4. In your browser, navigate to: ${chalk.green('http://localhost:8000')}\n
+ ${chalk.grey(
+   'Note: due to a limitation with concurrently, some output (django dev server) will not be displayed when the dirt-dev command is run.'
+ )}
+ ${chalk.gray(
+   "Workaround: Activate the shell and run 'python manage.py runserver' in a separate terminal and then 'npm run dirt-fe' in another terminal"
+ )}
 ${options['withStorybook'] ? storybookInstructions : ''}
 ${options['installPrettier'] ? prettierInstructions : ''}
 `);

--- a/templates/react-templates/package.json
+++ b/templates/react-templates/package.json
@@ -7,6 +7,7 @@
     "vite-build": "vite build",
     "vite-dev": "vite",
     "tailwind-dev": "tailwindcss -i ./static/css/main.css -o ./static/dist/css/app.css --watch",
+    "dirt-fe": "concurrently -c \"auto\" --names \"tailwind-css,dirt-frontend\" \"npm run tailwind-dev\" \"npm run vite-dev\"",
     "dirt-dev": "concurrently -c \"auto\" --names \"dirt-dev-server,tailwind-css,dirt-frontend\" \"exec ./manage.py runserver\" \"npm run tailwind-dev\" \"npm run vite-dev\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This PR updates the post scaffold messaging to reference limitation of concurrently with buffered output from the Django dev server. Include workaround text. See below

<img width="1399" alt="Screenshot 2023-04-08 at 12 08 23 AM" src="https://user-images.githubusercontent.com/97003335/230704698-792b11c1-37a4-4688-93c6-410d373086b3.png">
